### PR TITLE
Reorder subsections in "Getting Started" section

### DIFF
--- a/01_getting-started.adoc
+++ b/01_getting-started.adoc
@@ -15,6 +15,11 @@ For windows this is "build-windows.md", for macOS this is "build-osx.md" and for
 
 There is also a guide by Jon Atack about how to https://jonatack.github.io/articles/how-to-compile-bitcoin-core-and-run-the-tests[compile and test Bitcoin Core].
 
+=== Doxygen documentation
+
+Bitcoin Core uses https://www.doxygen.nl/index.html[Doxygen] to generate developer documentation automatically from its annotated C++ codebase.
+Developers can access documentation of the current release of Bitcoin Core online at https://doxygen.bitcoincore.org/[doxygen.bitcoincore.org], or alternatively can generate documentation for their current head using `make docs` (see https://github.com/bitcoin/bitcoin/tree/master/doc/developer-notes.md#generating-documentation[Generating Documentation] for more info).
+
 == Bitcoin contributor journeys
 
 Some contributors have documented their journeys into the space which let's us learn about approaches they found useful, but also any pitfalls and things they found difficult along the way.
@@ -22,11 +27,6 @@ Some contributors have documented their journeys into the space which let's us l
 * https://github.com/amitiuttarwar[Amiti Uttarwar] - https://medium.com/@amitiu/onboarding-to-bitcoin-core-7c1a83b20365[Onboarding to Bitcoin Core]
 * https://github.com/jonatack[Jon Atack] - https://jonatack.github.io/articles/on-reviewing-and-helping-those-who-do-it[On Reviewing, and Helping Those Who Do It]
 * https://github.com/jimmysong[Jimmy Song] - https://bitcointechtalk.com/a-gentle-introduction-to-bitcoin-core-development-fdc95eaee6b8[A Gentle Introduction to Bitcoin Core Development]
-
-== Doxygen documentation
-
-Bitcoin Core uses https://www.doxygen.nl/index.html[Doxygen] to generate developer documentation automatically from its annotated C++ codebase.
-Developers can access documentation of the current release of Bitcoin Core online at https://doxygen.bitcoincore.org/[doxygen.bitcoincore.org], or alternatively can generate documentation for their current head using `make docs` (see https://github.com/bitcoin/bitcoin/tree/master/doc/developer-notes.md#generating-documentation[Generating Documentation] for more info).
 
 == Bitcoin Core and GitHub
 
@@ -184,17 +184,17 @@ TIP: starting with `ping` and `pong` messages might be easiest
 * Submit your review of the PR as a GitHub comment on the PR
 
 // == Removed text
-// 
+//
 // === Goals
-// 
+//
 // * Learn how the Bitcoin Core project uses GitHub
 // * Learn how to compile the code from source
 // * Learn how to run the test suite
 // * Learn about other developers journeys into bitcoin dev
 // * PR review process
-// 
+//
 // === Concepts
-// 
+//
 // * GitHub usage
 // * Git usage
 // * Building bitcoin from source code


### PR DESCRIPTION
<p>“Building Bitcoin” is followed by “Contributor’s journey”, followed by “Doxygen documentation”. The ordering should be changed as 1st and 3rd are considerable from a developer’s point of view. While 2nd is kind of for the general audience who want to look into the developing environment around bitcoin.</p>
<p>Changes:</p>


|Master|PR|
|---------|-----|
|![Master=](https://user-images.githubusercontent.com/85434418/158523889-7a7a6565-8ebf-4c98-8297-aa373f94b518.png) |  ![PR](https://user-images.githubusercontent.com/85434418/158523912-70883853-ce31-4d6f-b246-2538bf63d42c.png)|




