### PR TITLE
autogen and configure were prepended with a '.'

### DIFF
--- a/01_overview-and-development.adoc
+++ b/01_overview-and-development.adoc
@@ -391,8 +391,8 @@ make distclean
 mkdir build && cd build
 
 # Run normal build sequence with amended path
-../.autogen.sh
-.././configure --your-normal-options-here
+../autogen.sh
+../configure --your-normal-options-here
 ../make -j `nproc`
 ../make check
 ----


### PR DESCRIPTION
Hey Jonas,
A couple of reasons for this pull request.
 1. Practice contributing to an open source project.
 2. I think this is a *maybe* is a bug.
 
I followed the instructions on the build path twice to double check after pulling down the bitcoin core repo.
My directory contents.
<img width="366" alt="Screen Shot 2022-07-22 at 6 16 27 PM" src="https://user-images.githubusercontent.com/45839100/180575612-76056a65-d5ea-49c5-b623-6ed82d2dd83b.png">



I noticed that autogen and configure don't start with a '.'.
So while in the build directory '../.autogen.sh' does not exist.
This is the same for configure.

Perhaps this code snippet is outdated?

Can anyone reproduce the following?

1. Clone / pull latest of bitcoin core repo.
2. Follow the instructions in the guide

- # Clean current source dir in case it was already configured
make distclean

# Make new build dir
mkdir build && cd build

# Run normal build sequence with amended path
.././autogen.sh
.././configure --your-normal-options-here
../make -j `nproc`
../make check




