### PR TITLE
Update make commands when using build directory

### DIFF
--- a/01_overview-and-development.adoc
+++ b/01_overview-and-development.adoc
@@ -342,8 +342,8 @@ mkdir build && cd build
 # Run normal build sequence with amended path
 ../autogen.sh
 ../configure --your-normal-options-here
-../make -j `nproc`
-../make check
+make -j `nproc`
+make check
 ----
 
 === Codebase documentation


### PR DESCRIPTION
I'm not sure if the following makes sense when using the recommended `build` directory:
- ../make -j `nproc`
- ../make check

When I tried to run them from `bitcoin/build`, I got this error: `bash: ../make: No such file or directory`, so I removed `../` from the commands.

Is it okay to run `make` commands straight from the build directory? Feel free to close this PR if PEBCAK :) and the current instructions are indeed correct.