### PR TITLE
Chapter 1, Add missing hyphen to command in regtest exercise

### DIFF
--- a/01_overview-and-development.adoc
+++ b/01_overview-and-development.adoc
@@ -415,7 +415,7 @@ $ src/bitcoin-cli -regtest -datadir=/tmp/regtest-datadir getblockchaininfo
   _(...)_
 }
 $ src/bitcoin-cli -regtest -datadir=/tmp/regtest-datadir createwallet testwallet
-$ src/bitcoin-cli -regtest -datadir=/tmp/regtest-datadir generate 3
+$ src/bitcoin-cli -regtest -datadir=/tmp/regtest-datadir -generate 3
 {
   "address": "bcrt1qpw3pjhtf9myl0qk9cxt54qt8qxu2mj955c7esx",
   "blocks": [


### PR DESCRIPTION
When I run the generate command in the regtest exercise, I get the following error:

```
src/bitcoin-cli -regtest -datadir=/tmp/regtest-datadir generate 3
error code: -1
error message:
generate

has been replaced by the -generate cli option. Refer to -help for more information.
```

Knowing that these docs have been updated for Bitcoin Core v23.0, I used what was taught in the Codebase Archaeology section to look up the git blame:
```
git blame -L239,239 src/rpc/mining.cpp
faaa46dc204 (MarcoFalke 2020-08-14 11:27:44 +0200 239)     return RPCHelpMan{"generate", "has been replaced by the -generate cli option. Refer to -help for more information.", {}, {}, RPCExamples{""}, [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
```

It looks like `generate` has been replaced by the `-generate` cli option for some time now, and when I add the hyphen to the command, it works as expected.