### PR TITLE
Chapter 3 - Add link to PR that renames CChainState

### DIFF
--- a/03_consensus-and-validation.adoc
+++ b/03_consensus-and-validation.adoc
@@ -1245,7 +1245,7 @@ There are a number of different states which the client must be able to handle:
 
 `BlockManager` is tasked with maintaining a tree of all blocks learned about, along with their total work so that the most-work chain can be quickly determined.
 
-`CChainState` is responsible for updating our local view of the best tip, including reading and writing blocks to disk, and updating the UTXO set.
+`CChainstate` (https://github.com/bitcoin/bitcoin/pull/24513[renamed^] to `Chainstate` in v24.0) is responsible for updating our local view of the best tip, including reading and writing blocks to disk, and updating the UTXO set.
 A single `BlockManager` is shared between all instances of `CChainState`.
 
 `ChainstateManager` is tasked with managing multiple ``CChainState``s.


### PR DESCRIPTION
Chapter 3: The [Multiple Chains](https://obc.256k1.dev/#_multiple_chains) section talks about the `CChainState` data structure, however it will be renamed to `Chainstate` in v24.0 per [PR #24513](https://github.com/bitcoin/bitcoin/pull/24513). 

I know this book explicitly states that it's written with v23.0 as a reference, but readers may be pointing to a more recent copy of the code, especially if they are periodically revisiting this book in between other activities like PR review. If they try to grep the code base for 'CChainState', they probably won't find anything. Maybe release notes if they are lucky?

The PR also has a delightful description and reviewing it is probably a good exercise for beginners in understanding the implications of a large renaming PR like this.

I understand it is simpler to leave this out, but I think there is a case to be made for mentioning the rename!