### PR TITLE
Hide answers for exercises

### DIFF
--- a/03_consensus-and-validation.adoc
+++ b/03_consensus-and-validation.adoc
@@ -672,6 +672,7 @@ TIP: For more information on `PeerManagerImpl` see <<pimpl-technique,PIMPL techn
 
 Transactions are internally represented as either a `CTransaction`, a `CTransactionRef` (a shared pointer to a `CTransaction`) or in the case of packages a `Package` which is a `std::vector<CTransactionRef>`.
 
+[#glozow-tx-mempool-validation]
 We can follow the journey of a transaction through the Bitcoin Core mempool by following glozow's https://github.com/glozow/bitcoin-notes/tree/e9855dc377811b6d77bb75d8606c776cc26c1860/transaction-lifecycle.md#Validation-and-Submission-to-Mempool[notes^] on transaction "Validation and Submission to the Mempool".
 glozow details the different types of checks that are run on a new transaction before it's accepted into the mempool, as well as breaking down how these checks are different from each other: consensus vs policy, script vs non-script, contextual vs context-free.
 
@@ -1275,55 +1276,116 @@ If you would like to learn more about the responsible disclosure process and why
 
 [qanda]
 What is the difference between contextual and context-free validation checks?::
++
+.Click for answer
+[%collapsible]
+====
 Contextual checks require some knowledge of the current "state", e.g. ChainState, chain tip or UTXO set.
-+
+
 Context-free checks only require the information required in the transaction itself.
-+
-See {glozow-tx-mempool-validation}[glozow-tx-mempool-validation] for more info.
+
+For more info, see <<glozow-tx-mempool-validation,glozow's notes>> on transaction "Validation and Submission to the Mempool".
+====
 
 What are some examples of each?::
-context-free:
 +
+.Click for answer
+[%collapsible]
+====
+context-free:
+
 . `tx.isCoinbase()`
 . https://github.com/bitcoin/bitcoin/tree/4b5659c6b115315c9fd2902b4edd4b960a5e066e/src/consensus/tx_check.cpp#L25-L28[0 &#8804; tx_value &#8804; MAX_MONEY^]
 . https://github.com/bitcoin/bitcoin/tree/4b5659c6b115315c9fd2902b4edd4b960a5e066e/src/policy/policy.cpp#L88[tx not overweight^]
 
-+
-contextual: https://github.com/bitcoin/bitcoin/tree/4b5659c6b115315c9fd2902b4edd4b960a5e066e/src/validation.cpp#L671-L692[check inputs are available^]
+contextual:
+
+. https://github.com/bitcoin/bitcoin/tree/4b5659c6b115315c9fd2902b4edd4b960a5e066e/src/validation.cpp#L671-L692[check inputs are available^]
+====
 
 In which function(s) do UTXO-related validity checks happen?::
++
+.Click for answer
+[%collapsible]
+====
 `ConnectBlock()`
+====
 
 What type of validation checks are `CheckBlockHeader()` and `CheckBlock()` performing?::
++
+.Click for answer
+[%collapsible]
+====
 context-free
+====
 
 Which class is in charge of managing the current blockchain?::
++
+.Click for answer
+[%collapsible]
+====
 `ChainstateManager()`
+====
 
 Which class is in charge of managing the UTXO set?::
++
+.Click for answer
+[%collapsible]
+====
 `CCoinsViews()`
+====
 
 Which functions are called when a longer chain is found that we need to re-org onto?::
 TODO
 
 Are there any areas of the codebase where the same consensus or validation checks are performed twice?::
-Again see https://github.com/glozow/bitcoin-notes/tree/e9855dc377811b6d77bb75d8606c776cc26c1860/transaction-lifecycle.md#Validation-and-Submission-to-Mempool[glozows notes^] for examples
++
+.Click for answer
+[%collapsible]
+====
+Again see https://github.com/glozow/bitcoin-notes/tree/e9855dc377811b6d77bb75d8606c776cc26c1860/transaction-lifecycle.md#Validation-and-Submission-to-Mempool[glozow's notes^] for examples
+====
 
 Why does `CheckInputsFromMempoolAndCache` exist?::
++
+.Click for answer
+[%collapsible]
+====
 To prevent us from re-checking the scripts of transactions already in our mempool during consensus validation on learning about a new block
+====
 
 Which function(s) are in charge of validating the merkle root of a block?::
++
+.Click for answer
+[%collapsible]
+====
 `BlockMerkleRoot()` and `BlockWitnessMerkleRoot()` construct a vector of merkle leaves, which is then passed to `ComputeMerkleRoot()` for calculation.
 // TODO: Calculate the merkle root of a sample block
+====
 
 Can you find any evidence (e.g. PRs) which have been made in an effort to modularize consensus code?::
++
+.Click for answer
+[%collapsible]
+====
 A few examples: https://github.com/bitcoin/bitcoin/pull/10279[PR#10279^], https://github.com/bitcoin/bitcoin/pull/20158[PR#20158^]
+====
 
 What is the function of `BlockManager()`?::
++
+.Click for answer
+[%collapsible]
+====
 It manages the current most-work chaintip and pruning of unneeded blocks (`\*.blk`) and associated undo (`*.rev`) files
+====
 
 What stops a malicious node from sending multiple invalid headers to try and use up a nodes' disk space? (hint: these might be stored in `BlockManager.m_failed_blocks`)::
++
+.Click for answer
+[%collapsible]
+====
 Even invalid headers would need a valid proof of work which would be too costly to construct for a spammer
+====
 
 Which functions are responsible for writing consensus-valid blocks to disk?::
 TODO: answer
@@ -1332,12 +1394,22 @@ Are there any other components to Bitcoin Core which, similarly to the block sto
 Not sure myself, sounds like an interesting question though!
 
 In which module (and class) is signature verification handled?::
++
+.Click for answer
+[%collapsible]
+====
 `src/script/interpreter.cpp#BaseSignatureChecker`
+====
 
 Which function is used to calculate the Merkle root of a block, and from where is it called?::
-`src/consensus/merkle.cpp#ComputeMerkleRoot` is used to compute the merkle root.
 +
+.Click for answer
+[%collapsible]
+====
+`src/consensus/merkle.cpp#ComputeMerkleRoot` is used to compute the merkle root.
+
 It is called from `src/chainparams.cpp#CreateGenesisBlock`, `src/miner.cpp#IncrementExtraNonce` & `src/miner.cpp#RegenerateCommitments` and from `src/validation.cpp#CheckBlock` to validate incoming blocks.
+====
 
 Practical question on Merkle root calculation::
 TODO, add more Exercises

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,5 @@
 = Onboarding to Bitcoin Core
 
 This documentation is currently hosted at https://obc.256k1.dev[obc.256k1.dev] however this location may be subject to change in the future.
+
+See [asciidoc_workflow.adoc](https://github.com/chaincodelabs/onboarding-to-bitcoin-core/blob/master/asciidoc_workflow.adoc) for tips on contributing and instructions for running locally.


### PR DESCRIPTION
I'm not sure if this is possible or desired, but wanted to propose hiding the answers for the exercises, starting with chapter 3. This would be similar to the various "Click to see xyz" sections in the book. 

Is there a way I can run this locally to check that the change works?

If this is a good idea, I'm happy to update the rest of the exercises so the answers are initially collapsed.