### PR TITLE
fix lint checks instruction

### DIFF
--- a/testing.adoc
+++ b/testing.adoc
@@ -24,7 +24,7 @@ Or you can run all checks with:
 
 [source,bash]
 ----
-python test/lint/all-lint.py
+cd ./test/lint/test_runner/ && cargo fmt && cargo clippy && cargo run
 ----
 
 NOTE: Previously these checks were shell scripts (`*.sh`), but they have now been migrated to python on master.

--- a/tests-overview.adoc
+++ b/tests-overview.adoc
@@ -16,7 +16,7 @@
 |`test/functional/test_runner.py`
 
 |lint checks
-|`test/lint/all-lint.py`
+|See the https://github.com/bitcoin/bitcoin/blob/master/test/lint/README.md#running-locally[documentation^]
 
 |fuzz
 |See the https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md[documentation^]


### PR DESCRIPTION
`all-lint.py` was removed from Bitcoin Core. This PR updates the instructions to run the lint checks.