### PR TITLE
 add dark mode toggle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,8 @@ github_username:  chaincodelabs
 
 # Build settings
 theme: just-the-docs
+# Color scheme supports "light" (default) and "dark"
+color_scheme: dark
 plugins:
   - asciidoctor-diagram
   - jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ github_username:  chaincodelabs
 
 # Build settings
 theme: just-the-docs
-# Color scheme supports "light" (default) and "dark"
+# Color scheme supports "light" and "dark"
 color_scheme: dark
 plugins:
   - asciidoctor-diagram

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,19 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="/css/asciidoc.css">
+
+<button class="btn js-toggle-dark-mode"><i class="fa fa-sun-o"></i></button>
+
+<script>
+const toggleDarkMode = document.querySelector('.js-toggle-dark-mode');
+const toggleIcon = toggleDarkMode.querySelector('i');
+
+jtd.addEvent(toggleDarkMode, 'click', function() {
+  if (jtd.getTheme() === 'dark') {
+    jtd.setTheme('light');
+    toggleIcon.className = 'fa fa-moon-o';
+  } else {
+    jtd.setTheme('dark');
+    toggleIcon.className = 'fa fa-sun-o';
+  }
+});
+</script>


### PR DESCRIPTION
Add Dark Mode toggle using jekyll's just-the-docs sample switcher
Just a simple first pass. See video. 
Will be AFK for a while. Back in the new year. 

https://github.com/user-attachments/assets/757aa6a8-142d-4e09-89dd-fdbdf1a570c9

