### PR TITLE
ci: bump action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Configure Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Install Ruby and Jekyll
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Configure Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Install Ruby and Jekyll
         uses: ruby/setup-ruby@v1
         with:
@@ -45,7 +45,7 @@ jobs:
           JEKYLL_ENV: production
           ADD_JEKYLL_ARGS: --baseurl "${{ steps.pages.outputs.base_path }}"
       - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
   deploy:
     runs-on: ubuntu-latest
     needs: build-jekyll
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Hopefully this will fix the slightly cryptic [CI failures](https://github.com/chaincodelabs/onboarding-to-bitcoin-core/actions/runs/13946245475/job/39034043949):

```log
Current runner version: '2.322.0'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@v4' (SHA:11bd71901bbe5b1630ceea73d27597364c9af683)
Download action repository 'actions/configure-pages@v3' (SHA:b8130d9ab958b325bbde9786d62f2c97a9885a0e)
Download action repository 'ruby/setup-ruby@v1' (SHA:1a615958ad9d422dd932dc1d5823942ee002799f)
Download action repository 'actions/setup-node@v4' (SHA:cdca7365b2dadb8aad0a33bc7601856ffabcc48e)
Download action repository 'actions/upload-pages-artifact@v1' (SHA:84bb4cd4b733d5c320c9c9cfbc354937524f4d64)
Getting action download info
Error: Missing download info for actions/upload-artifact@v3
```